### PR TITLE
audit: WCAG, SEO, responsiveness, and optimization pass

### DIFF
--- a/app/components/shared/GuideModal.tsx
+++ b/app/components/shared/GuideModal.tsx
@@ -16,14 +16,12 @@ const GuideModal: React.FC<GuideModalProps> = ({ isOpen, onClose }) => {
 	const modalRef = useRef<HTMLDivElement>(null);
 	const closeButtonRef = useRef<HTMLButtonElement>(null);
 
-	// Focus the close button when modal opens
 	useEffect(() => {
 		if (isOpen) {
 			closeButtonRef.current?.focus();
 		}
 	}, [isOpen]);
 
-	// Focus trap + close key handling
 	const handleKeyDown = useCallback(
 		(e: KeyboardEvent) => {
 			if (!isOpen) return;
@@ -34,7 +32,6 @@ const GuideModal: React.FC<GuideModalProps> = ({ isOpen, onClose }) => {
 				return;
 			}
 
-			// Tab trap: keep focus inside the modal
 			if (e.key === "Tab") {
 				const modal = modalRef.current;
 				if (!modal) return;
@@ -68,8 +65,8 @@ const GuideModal: React.FC<GuideModalProps> = ({ isOpen, onClose }) => {
 	);
 
 	useEffect(() => {
-		window.addEventListener("keydown", handleKeyDown);
-		return () => window.removeEventListener("keydown", handleKeyDown);
+		globalThis.addEventListener("keydown", handleKeyDown);
+		return () => globalThis.removeEventListener("keydown", handleKeyDown);
 	}, [handleKeyDown]);
 
 	return (

--- a/app/globals.scss
+++ b/app/globals.scss
@@ -35,6 +35,19 @@ code {
     source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
 
+/* Visually hidden but available to screen readers */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 ::-webkit-scrollbar {
   display: none;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,12 +3,12 @@ import "./globals.scss";
 import "./styles/guide-modal.scss";
 import Script from "next/script";
 
-const BASE_URL = "https://carsonsgit.github.io";
+const BASE_URL = "https://carsonspriggs.me";
 
 export const metadata: Metadata = {
-	title: "Carson Spriggs — Software Developer & Student",
+	title: "carsonSgit",
 	description:
-		"Portfolio of Carson Spriggs, a software developer and engineering student at Memorial University. Co-Chair of CUSEC, CS alumni of John Abbott College. Projects in AI, IoT, full-stack, and more.",
+		"Portfolio of Carson Spriggs. Fullstack developer, AI research, UI/UX.",
 	authors: [{ name: "Carson Spriggs" }],
 	keywords: [
 		"Carson Spriggs",
@@ -16,10 +16,8 @@ export const metadata: Metadata = {
 		"portfolio",
 		"full-stack",
 		"AI",
-		"React",
-		"Next.js",
-		"TypeScript",
 		"Memorial University",
+		"Concordia University",
 		"CUSEC",
 		"John Abbott College",
 	],
@@ -27,24 +25,6 @@ export const metadata: Metadata = {
 		icon: "/favicon.ico",
 	},
 	manifest: "/manifest.json",
-	alternates: {
-		canonical: BASE_URL,
-	},
-	openGraph: {
-		title: "Carson Spriggs — Software Developer & Student",
-		description:
-			"Portfolio of Carson Spriggs, a software developer and engineering student at Memorial University. Co-Chair of CUSEC, CS alumni of John Abbott College.",
-		url: BASE_URL,
-		siteName: "Carson Spriggs Portfolio",
-		locale: "en_US",
-		type: "website",
-	},
-	twitter: {
-		card: "summary",
-		title: "Carson Spriggs — Software Developer & Student",
-		description:
-			"Portfolio of Carson Spriggs, a software developer and engineering student at Memorial University. Co-Chair of CUSEC, CS alumni of John Abbott College.",
-	},
 };
 
 export const viewport: Viewport = {
@@ -73,6 +53,11 @@ const jsonLd = {
 		},
 		{
 			"@type": "CollegeOrUniversity",
+			name: "Concordia University",
+			url: "https://www.concordia.ca/",
+		},
+		{
+			"@type": "CollegeOrUniversity",
 			name: "John Abbott College",
 			url: "https://www.johnabbott.qc.ca/",
 		},
@@ -87,45 +72,45 @@ const jsonLd = {
 	],
 };
 
-export default function RootLayout({
-	children,
-}: {
-	children: React.ReactNode;
-}) {
-	return (
-		<html lang="en" data-theme="mono">
-			<head>
-				{/* Preconnect to analytics origin to reduce latency */}
-				<link rel="preconnect" href="https://cloud.umami.is" />
-				<link
-					rel="preload"
-					href="/fonts/CommitMono-400-Regular.woff2"
-					as="font"
-					type="font/woff2"
-					crossOrigin="anonymous"
-				/>
-				<link
-					rel="preload"
-					href="/fonts/CommitMono-700-Regular.woff2"
-					as="font"
-					type="font/woff2"
-					crossOrigin="anonymous"
-				/>
-				<script
-					type="application/ld+json"
-					// biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD, no user input
-					dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-				/>
-			</head>
-			<body className="theme-mono">
-				{children}
-				<Script
-					src="https://cloud.umami.is/script.js"
-					data-website-id="3a4253fc-dee7-4c4e-bd4a-a5eba54a2df1"
-					strategy="afterInteractive"
-					defer
-				/>
-			</body>
-		</html>
-	);
-}
+export default function RootLayout
+	(
+		{ children }: 
+		{ readonly children: React.ReactNode; }
+	) 
+	{
+		return (
+			<html lang="en" data-theme="mono">
+				<head>
+					<link rel="preconnect" href="https://cloud.umami.is" />
+					<link
+						rel="preload"
+						href="/fonts/CommitMono-400-Regular.woff2"
+						as="font"
+						type="font/woff2"
+						crossOrigin="anonymous"
+					/>
+					<link
+						rel="preload"
+						href="/fonts/CommitMono-700-Regular.woff2"
+						as="font"
+						type="font/woff2"
+						crossOrigin="anonymous"
+					/>
+					<script
+						type="application/ld+json"
+						// biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD, no user input
+						dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+					/>
+				</head>
+				<body className="theme-mono">
+					{children}
+					<Script
+						src="https://cloud.umami.is/script.js"
+						data-website-id="3a4253fc-dee7-4c4e-bd4a-a5eba54a2df1"
+						strategy="afterInteractive"
+						defer
+					/>
+				</body>
+			</html>
+		);
+	}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -106,6 +106,7 @@ export default function RootLayout({
 				<Script
 					src="https://cloud.umami.is/script.js"
 					data-website-id="3a4253fc-dee7-4c4e-bd4a-a5eba54a2df1"
+					data-cache="false"
 					strategy="afterInteractive"
 					defer
 				/>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -72,45 +72,44 @@ const jsonLd = {
 	],
 };
 
-export default function RootLayout
-	(
-		{ children }: 
-		{ readonly children: React.ReactNode; }
-	) 
-	{
-		return (
-			<html lang="en" data-theme="mono">
-				<head>
-					<link rel="preconnect" href="https://cloud.umami.is" />
-					<link
-						rel="preload"
-						href="/fonts/CommitMono-400-Regular.woff2"
-						as="font"
-						type="font/woff2"
-						crossOrigin="anonymous"
-					/>
-					<link
-						rel="preload"
-						href="/fonts/CommitMono-700-Regular.woff2"
-						as="font"
-						type="font/woff2"
-						crossOrigin="anonymous"
-					/>
-					<script
-						type="application/ld+json"
-						// biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD, no user input
-						dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-					/>
-				</head>
-				<body className="theme-mono">
-					{children}
-					<Script
-						src="https://cloud.umami.is/script.js"
-						data-website-id="3a4253fc-dee7-4c4e-bd4a-a5eba54a2df1"
-						strategy="afterInteractive"
-						defer
-					/>
-				</body>
-			</html>
-		);
-	}
+export default function RootLayout({
+	children,
+}: {
+	readonly children: React.ReactNode;
+}) {
+	return (
+		<html lang="en" data-theme="mono">
+			<head>
+				<link rel="preconnect" href="https://cloud.umami.is" />
+				<link
+					rel="preload"
+					href="/fonts/CommitMono-400-Regular.woff2"
+					as="font"
+					type="font/woff2"
+					crossOrigin="anonymous"
+				/>
+				<link
+					rel="preload"
+					href="/fonts/CommitMono-700-Regular.woff2"
+					as="font"
+					type="font/woff2"
+					crossOrigin="anonymous"
+				/>
+				<script
+					type="application/ld+json"
+					// biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD, no user input
+					dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+				/>
+			</head>
+			<body className="theme-mono">
+				{children}
+				<Script
+					src="https://cloud.umami.is/script.js"
+					data-website-id="3a4253fc-dee7-4c4e-bd4a-a5eba54a2df1"
+					strategy="afterInteractive"
+					defer
+				/>
+			</body>
+		</html>
+	);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,33 +3,88 @@ import "./globals.scss";
 import "./styles/guide-modal.scss";
 import Script from "next/script";
 
+const BASE_URL = "https://carsonsgit.github.io";
+
 export const metadata: Metadata = {
-	title: "carsonSgit Portfolio",
+	title: "Carson Spriggs — Software Developer & Student",
 	description:
-		"My personal portfolio. Showcasing my projects, experience, and more.",
+		"Portfolio of Carson Spriggs, a software developer and engineering student at Memorial University. Co-Chair of CUSEC, CS alumni of John Abbott College. Projects in AI, IoT, full-stack, and more.",
+	authors: [{ name: "Carson Spriggs" }],
+	keywords: [
+		"Carson Spriggs",
+		"software developer",
+		"portfolio",
+		"full-stack",
+		"AI",
+		"React",
+		"Next.js",
+		"TypeScript",
+		"Memorial University",
+		"CUSEC",
+		"John Abbott College",
+	],
 	icons: {
 		icon: "/favicon.ico",
 	},
 	manifest: "/manifest.json",
+	alternates: {
+		canonical: BASE_URL,
+	},
 	openGraph: {
-		title: "carsonSgit Portfolio",
+		title: "Carson Spriggs — Software Developer & Student",
 		description:
-			"My personal portfolio. Showcasing my projects, experience, and more.",
-		url: "https://carsonsgit.github.io",
-		siteName: "carsonSgit Portfolio",
+			"Portfolio of Carson Spriggs, a software developer and engineering student at Memorial University. Co-Chair of CUSEC, CS alumni of John Abbott College.",
+		url: BASE_URL,
+		siteName: "Carson Spriggs Portfolio",
 		locale: "en_US",
 		type: "website",
 	},
 	twitter: {
 		card: "summary",
-		title: "carsonSgit Portfolio",
+		title: "Carson Spriggs — Software Developer & Student",
 		description:
-			"My personal portfolio. Showcasing my projects, experience, and more.",
+			"Portfolio of Carson Spriggs, a software developer and engineering student at Memorial University. Co-Chair of CUSEC, CS alumni of John Abbott College.",
 	},
 };
 
 export const viewport: Viewport = {
 	themeColor: "#0d0d0f",
+};
+
+const jsonLd = {
+	"@context": "https://schema.org",
+	"@type": "Person",
+	name: "Carson Spriggs",
+	url: BASE_URL,
+	sameAs: [
+		"https://github.com/carsonSgit",
+		"https://linkedin.com/in/carsonspriggs",
+	],
+	jobTitle: "Software Developer",
+	worksFor: {
+		"@type": "Organization",
+		name: "Botpress",
+	},
+	alumniOf: [
+		{
+			"@type": "CollegeOrUniversity",
+			name: "Memorial University of Newfoundland",
+			url: "https://www.mun.ca/",
+		},
+		{
+			"@type": "CollegeOrUniversity",
+			name: "John Abbott College",
+			url: "https://www.johnabbott.qc.ca/",
+		},
+	],
+	knowsAbout: [
+		"Software Development",
+		"Artificial Intelligence",
+		"IoT",
+		"Full-Stack Development",
+		"DevOps",
+		"Machine Learning",
+	],
 };
 
 export default function RootLayout({
@@ -40,6 +95,8 @@ export default function RootLayout({
 	return (
 		<html lang="en" data-theme="mono">
 			<head>
+				{/* Preconnect to analytics origin to reduce latency */}
+				<link rel="preconnect" href="https://cloud.umami.is" />
 				<link
 					rel="preload"
 					href="/fonts/CommitMono-400-Regular.woff2"
@@ -54,14 +111,21 @@ export default function RootLayout({
 					type="font/woff2"
 					crossOrigin="anonymous"
 				/>
+				<script
+					type="application/ld+json"
+					// biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD, no user input
+					dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+				/>
 			</head>
-			<Script
-				src="https://cloud.umami.is/script.js"
-				data-website-id="3a4253fc-dee7-4c4e-bd4a-a5eba54a2df1"
-				strategy="afterInteractive"
-				defer
-			/>
-			<body className="theme-mono">{children}</body>
+			<body className="theme-mono">
+				{children}
+				<Script
+					src="https://cloud.umami.is/script.js"
+					data-website-id="3a4253fc-dee7-4c4e-bd4a-a5eba54a2df1"
+					strategy="afterInteractive"
+					defer
+				/>
+			</body>
 		</html>
 	);
 }

--- a/app/styles/guide-modal.scss
+++ b/app/styles/guide-modal.scss
@@ -6,7 +6,8 @@
   --guide-modal-border: rgba(255, 255, 255, 0.1);
   --guide-modal-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
   --guide-text: #e8e8ec;
-  --guide-text-muted: #71717a;
+  // Increased from #71717a → #8a8a94 for WCAG AA contrast on modal background
+  --guide-text-muted: #8a8a94;
   --guide-border: rgba(255, 255, 255, 0.1);
   --guide-surface: rgba(255, 255, 255, 0.03);
   --guide-accent: #60a5fa;
@@ -36,11 +37,19 @@
   kbd {
     font-family: 'CommitMono', monospace;
     font-size: 0.875rem;
-    color: #71717a;
+    color: #8a8a94;
     transition: color 150ms ease;
   }
 
-  &:hover,
+  &:hover {
+    border-color: #60a5fa;
+    background: rgba(255, 255, 255, 0.06);
+
+    kbd {
+      color: #e8e8ec;
+    }
+  }
+
   &:focus {
     border-color: #60a5fa;
     background: rgba(255, 255, 255, 0.06);
@@ -49,6 +58,11 @@
     kbd {
       color: #e8e8ec;
     }
+  }
+
+  &:focus-visible {
+    outline: 2px solid #60a5fa;
+    outline-offset: 2px;
   }
 
   @media (max-width: 768px) {
@@ -138,6 +152,16 @@
 
     &:hover {
       color: var(--guide-text);
+    }
+
+    &:focus {
+      color: var(--guide-text);
+      outline: none;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--guide-accent);
+      outline-offset: 2px;
     }
   }
 

--- a/app/themes/mono/components/AsciiFooter.tsx
+++ b/app/themes/mono/components/AsciiFooter.tsx
@@ -26,6 +26,7 @@ const AsciiFooter = () => {
 			<pre className="ascii-footer__art" aria-hidden="true">
 				{PENGUIN}
 			</pre>
+			<p className="sr-only">Thanks for stopping by!</p>
 		</footer>
 	);
 };

--- a/app/themes/mono/components/BracketLink.tsx
+++ b/app/themes/mono/components/BracketLink.tsx
@@ -4,10 +4,13 @@ interface BracketLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 	children: React.ReactNode;
 }
 
-const BracketLink = ({ children, ...props }: BracketLinkProps) => {
+const BracketLink = ({ children, target, ...props }: BracketLinkProps) => {
 	return (
-		<a className="bracket-link" {...props}>
+		<a className="bracket-link" target={target} {...props}>
 			{children}
+			{target === "_blank" && (
+				<span className="sr-only">(opens in new tab)</span>
+			)}
 		</a>
 	);
 };

--- a/app/themes/mono/components/EducationList.tsx
+++ b/app/themes/mono/components/EducationList.tsx
@@ -5,8 +5,8 @@ import { educationExp } from "../../../data/experiences";
 
 const EducationList = () => {
 	return (
-		<section>
-			<h2>Education</h2>
+		<section aria-labelledby="education-heading">
+			<h2 id="education-heading">Education</h2>
 			<Accordion.Root multiple className="section-list" aria-label="Education">
 				{educationExp.map((item) => {
 					const dateRange = item.date.join(" - ");
@@ -35,6 +35,7 @@ const EducationList = () => {
 												onKeyDown={(e) => e.stopPropagation()}
 											>
 												@ {item.institution}
+												<span className="sr-only">(opens in new tab)</span>
 											</a>
 										</span>
 									</div>

--- a/app/themes/mono/components/ExperienceList.tsx
+++ b/app/themes/mono/components/ExperienceList.tsx
@@ -5,8 +5,8 @@ import { professionalExp } from "../../../data/experiences";
 
 const ExperienceList = () => {
 	return (
-		<section>
-			<h2>Experience</h2>
+		<section aria-labelledby="experience-heading">
+			<h2 id="experience-heading">Experience</h2>
 			<Accordion.Root multiple className="section-list" aria-label="Experience">
 				{professionalExp.map((item) => {
 					const dateRange = item.date.join(" - ");
@@ -35,6 +35,7 @@ const ExperienceList = () => {
 												onKeyDown={(e) => e.stopPropagation()}
 											>
 												@ {item.institution}
+												<span className="sr-only">(opens in new tab)</span>
 											</a>
 										</span>
 									</div>

--- a/app/themes/mono/components/Intro.tsx
+++ b/app/themes/mono/components/Intro.tsx
@@ -9,15 +9,20 @@ const LINKS = [
 
 const Intro = () => {
 	return (
-		<section className="intro">
+		<section className="intro" aria-labelledby="intro-heading">
 			<div className="intro__header">
 				<Avatar.Root className="intro__avatar">
-					<Avatar.Image src="/klungo.png" alt="Carson Spriggs" />
+					<Avatar.Image
+						src="/klungo.png"
+						alt="Carson Spriggs"
+						width={56}
+						height={56}
+					/>
 					<Avatar.Fallback>CS</Avatar.Fallback>
 				</Avatar.Root>
 
 				<div className="intro__title-group">
-					<h1>Carson</h1>
+					<h1 id="intro-heading">Carson</h1>
 					<p className="intro__subtitle">Software Developer @ Botpress</p>
 				</div>
 			</div>

--- a/app/themes/mono/components/ProjectList.tsx
+++ b/app/themes/mono/components/ProjectList.tsx
@@ -8,8 +8,8 @@ import ProjectDetail from "./ProjectDetail";
 
 const ProjectList = () => {
 	return (
-		<section>
-			<h2>Projects</h2>
+		<section aria-labelledby="projects-heading">
+			<h2 id="projects-heading">Projects</h2>
 			<Accordion.Root multiple className="section-list" aria-label="Projects">
 				{projects.map((project: z.infer<typeof projectSchema>) => (
 					<Accordion.Item

--- a/app/themes/mono/hooks/useVimNavigation.ts
+++ b/app/themes/mono/hooks/useVimNavigation.ts
@@ -1,13 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 interface UseVimNavigationOptions {
 	containerRef: React.RefObject<HTMLElement | null>;
 	disabled?: boolean;
 }
-
-const ZOOM_LEVELS = [0.8, 0.9, 1.0, 1.1, 1.2];
-const ZOOM_DEFAULT_INDEX = 2;
-const ZOOM_STORAGE_KEY = "mono-portfolio-zoom";
 
 export function useVimNavigation({
 	containerRef,
@@ -15,29 +11,6 @@ export function useVimNavigation({
 }: UseVimNavigationOptions) {
 	const lastKeyRef = useRef<string>("");
 	const lastKeyTimeRef = useRef<number>(0);
-
-	// Zoom state
-	const [zoomIndex, setZoomIndex] = useState<number>(() => {
-		if (typeof window === "undefined") return ZOOM_DEFAULT_INDEX;
-		const stored = localStorage.getItem(ZOOM_STORAGE_KEY);
-		if (stored) {
-			const parsed = Number.parseInt(stored, 10);
-			if (parsed >= 0 && parsed < ZOOM_LEVELS.length) {
-				return parsed;
-			}
-		}
-		return ZOOM_DEFAULT_INDEX;
-	});
-
-	// Apply zoom on mount and when zoomIndex changes
-	useEffect(() => {
-		if (containerRef.current) {
-			const scale = ZOOM_LEVELS[zoomIndex];
-			containerRef.current.style.transform =
-				scale === 1 ? "" : `scale(${scale})`;
-		}
-		localStorage.setItem(ZOOM_STORAGE_KEY, zoomIndex.toString());
-	}, [zoomIndex, containerRef]);
 
 	const getNavigationRows = useCallback((): HTMLElement[][] => {
 		if (!containerRef.current) return [];
@@ -58,7 +31,6 @@ export function useVimNavigation({
 			if (socialLinks.length > 0) rows.push(socialLinks);
 		}
 
-		// Get all accordion triggers (the actual focusable elements)
 		const allTriggers = containerRef.current.querySelectorAll<HTMLElement>(
 			".section-list__trigger",
 		);
@@ -127,8 +99,10 @@ export function useVimNavigation({
 
 		if (row === -1) {
 			if (rows.length > 0) {
-				const lastRow = rows[rows.length - 1];
-				focusElement(lastRow[lastRow.length - 1]);
+				const lastRow = rows.at(-1);
+				if (lastRow && lastRow.length > 0) {
+					focusElement(lastRow.at(-1)!);
+				}
 			}
 			return;
 		}
@@ -169,8 +143,10 @@ export function useVimNavigation({
 
 		if (row === -1) {
 			if (rows.length > 0) {
-				const lastRow = rows[rows.length - 1];
-				focusElement(lastRow[lastRow.length - 1]);
+				const lastRow = rows.at(-1);
+				if (lastRow && lastRow.length > 0) {
+					focusElement(lastRow.at(-1)!);
+				}
 			}
 			return;
 		}
@@ -182,11 +158,13 @@ export function useVimNavigation({
 		} else if (row > 0) {
 			// At start of row, wrap to end of previous row
 			const prevRow = rows[row - 1];
-			focusElement(prevRow[prevRow.length - 1]);
+			focusElement(prevRow.at(-1)!);
 		} else {
 			// At start of first row, wrap to end of last row
-			const lastRow = rows[rows.length - 1];
-			focusElement(lastRow[lastRow.length - 1]);
+			const lastRow = rows.at(-1);
+			if (lastRow) {
+				focusElement(lastRow.at(-1)!);
+			}
 		}
 	}, [getNavigationRows, getCurrentPosition, focusElement]);
 
@@ -200,18 +178,12 @@ export function useVimNavigation({
 	const focusLast = useCallback(() => {
 		const rows = getNavigationRows();
 		if (rows.length > 0) {
-			const lastRow = rows[rows.length - 1];
-			focusElement(lastRow[lastRow.length - 1]);
+			const lastRow = rows.at(-1);
+			if (lastRow) {
+				focusElement(lastRow.at(-1)!);
+			}
 		}
 	}, [getNavigationRows, focusElement]);
-
-	const zoomIn = useCallback(() => {
-		setZoomIndex((prev) => Math.min(prev + 1, ZOOM_LEVELS.length - 1));
-	}, []);
-
-	const zoomOut = useCallback(() => {
-		setZoomIndex((prev) => Math.max(prev - 1, 0));
-	}, []);
 
 	const isInSubgroupLink = useCallback((): boolean => {
 		const active = document.activeElement as HTMLElement;
@@ -228,8 +200,230 @@ export function useVimNavigation({
 				".section-list__trigger",
 			) as HTMLElement | null;
 		}
-		return active?.closest(".section-list__trigger") as HTMLElement | null;
+		return active?.closest(".section-list__trigger");
 	}, []);
+
+	// Key mapping constants
+	const DOWN_KEYS = new Set(["k", "s", "ArrowDown"]);
+	const UP_KEYS = new Set(["i", "w", "ArrowUp"]);
+	const RIGHT_KEYS = new Set(["l", "d", "ArrowRight"]);
+	const LEFT_KEYS = new Set(["j", "a", "ArrowLeft"]);
+
+	// Helper function for parent trigger actions
+	const handleParentTriggerAction = useCallback(
+		(action: "focus" | "click" | "clickAndFocus", then?: () => void) => {
+			const parentItem = getParentTrigger();
+			if (parentItem) {
+				if (action === "click" || action === "clickAndFocus") {
+					parentItem.click();
+				}
+				if (action === "focus" || action === "clickAndFocus") {
+					parentItem.focus();
+				}
+				if (then) {
+					setTimeout(then, 0);
+				}
+			}
+		},
+		[getParentTrigger],
+	);
+
+	// Handle section navigation (number keys 1-4)
+	const handleSectionNavigation = useCallback(
+		(key: string) => {
+			if (key >= "1" && key <= "4") {
+				const sectionIndex = Number.parseInt(key, 10) - 1;
+				const sections = containerRef.current?.querySelectorAll("section");
+				if (sections?.[sectionIndex]) {
+					const section = sections[sectionIndex];
+					section.scrollIntoView({ behavior: "smooth", block: "start" });
+					const firstFocusable = section.querySelector<HTMLElement>(
+						'[tabindex="0"], a[href]',
+					);
+					firstFocusable?.focus();
+				}
+			}
+		},
+		[containerRef],
+	);
+
+	// Handle double-key sequence (gg for focusFirst)
+	const handleDoubleKeySequence = useCallback(
+		(key: string, now: number): boolean => {
+			if (key === "g") {
+				if (
+					lastKeyRef.current === "g" &&
+					now - lastKeyTimeRef.current < 500
+				) {
+					focusFirst();
+					window.scrollTo({ top: 0, behavior: "smooth" });
+					lastKeyRef.current = "";
+					return true;
+				}
+				lastKeyRef.current = "g";
+				lastKeyTimeRef.current = now;
+				return true;
+			}
+			return false;
+		},
+		[focusFirst],
+	);
+
+	// Handle subgroup link navigation
+	const handleSubgroupLinkKey = useCallback(
+		(e: KeyboardEvent): boolean => {
+			const active = document.activeElement as HTMLElement;
+
+			if (RIGHT_KEYS.has(e.key)) {
+				e.preventDefault();
+				const links = getSubgroupLinks();
+				const currentIdx = links.indexOf(active);
+				if (currentIdx !== -1 && currentIdx < links.length - 1) {
+					links[currentIdx + 1].focus();
+				} else {
+					handleParentTriggerAction("clickAndFocus", focusDown);
+				}
+				return true;
+			}
+
+			if (LEFT_KEYS.has(e.key)) {
+				e.preventDefault();
+				const links = getSubgroupLinks();
+				const currentIdx = links.indexOf(active);
+				if (currentIdx > 0) {
+					links[currentIdx - 1].focus();
+				} else {
+					handleParentTriggerAction("focus");
+				}
+				return true;
+			}
+
+			if (DOWN_KEYS.has(e.key)) {
+				e.preventDefault();
+				handleParentTriggerAction("clickAndFocus", focusDown);
+				return true;
+			}
+
+			if (UP_KEYS.has(e.key)) {
+				e.preventDefault();
+				handleParentTriggerAction("clickAndFocus", focusUp);
+				return true;
+			}
+
+			if (e.key === "q" || e.key === "Escape") {
+				e.preventDefault();
+				handleParentTriggerAction("clickAndFocus");
+				return true;
+			}
+
+			if (e.key === "Enter" || e.key === " ") {
+				return true;
+			}
+
+			return false;
+		},
+		[getSubgroupLinks, handleParentTriggerAction, focusDown, focusUp],
+	);
+
+	// Handle main navigation keys
+	const handleMainNavigationKey = useCallback(
+		(e: KeyboardEvent, isInContainer: boolean, active: HTMLElement) => {
+			if (DOWN_KEYS.has(e.key)) {
+				e.preventDefault();
+				focusDown();
+				return;
+			}
+
+			if (UP_KEYS.has(e.key)) {
+				e.preventDefault();
+				focusUp();
+				return;
+			}
+
+			if (RIGHT_KEYS.has(e.key)) {
+				e.preventDefault();
+				if (isInContainer && active) {
+					const isExpanded = active.getAttribute("aria-expanded") === "true";
+					const isTrigger = active.classList.contains("section-list__trigger");
+
+					if (isTrigger) {
+						if (isExpanded) {
+							const links = getSubgroupLinks();
+							if (links.length > 0) {
+								links[0].focus();
+							} else {
+								active.click();
+								focusDown();
+							}
+						} else {
+							active.click();
+						}
+					} else {
+						focusRight();
+					}
+				} else {
+					focusRight();
+				}
+				return;
+			}
+
+			if (LEFT_KEYS.has(e.key)) {
+				e.preventDefault();
+				if (isInContainer && active) {
+					const isExpanded = active.getAttribute("aria-expanded") === "true";
+					const isTrigger = active.classList.contains("section-list__trigger");
+
+					if (isTrigger && isExpanded) {
+						active.click();
+					} else {
+						focusLeft();
+					}
+				} else {
+					focusLeft();
+				}
+				return;
+			}
+
+			if (e.key === "q" || e.key === "Escape") {
+				if (isInContainer && active) {
+					if (active.getAttribute("aria-expanded") === "true") {
+						e.preventDefault();
+						active.click();
+					}
+				}
+				return;
+			}
+
+			if (e.key === "G" || e.key === "End") {
+				e.preventDefault();
+				focusLast();
+				window.scrollTo({
+					top: document.body.scrollHeight,
+					behavior: "smooth",
+				});
+				return;
+			}
+
+			if (e.key === "Home") {
+				e.preventDefault();
+				focusFirst();
+				window.scrollTo({ top: 0, behavior: "smooth" });
+				return;
+			}
+
+			handleSectionNavigation(e.key);
+		},
+		[
+			focusDown,
+			focusUp,
+			focusRight,
+			focusLeft,
+			focusFirst,
+			focusLast,
+			getSubgroupLinks,
+			handleSectionNavigation,
+		],
+	);
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
@@ -243,242 +437,44 @@ export function useVimNavigation({
 			}
 
 			const now = Date.now();
-			const isInContainer = containerRef.current?.contains(
-				document.activeElement,
-			);
-
-			if (e.key === "+" || e.key === "=") {
-				e.preventDefault();
-				zoomIn();
-				return;
-			}
-			if (e.key === "-") {
-				e.preventDefault();
-				zoomOut();
-				return;
-			}
-
+			const isInContainer: boolean =
+				containerRef.current?.contains(document.activeElement) ?? false;
 			const active = document.activeElement as HTMLElement;
-			const inSubgroupLink = isInSubgroupLink();
 
-			if (inSubgroupLink) {
-				switch (e.key) {
-					case "l":
-					case "d":
-					case "ArrowRight": {
-						e.preventDefault();
-						const links = getSubgroupLinks();
-						const currentIdx = links.indexOf(active);
-						if (currentIdx !== -1 && currentIdx < links.length - 1) {
-							links[currentIdx + 1].focus();
-						} else {
-							const parentItem = getParentTrigger();
-							if (parentItem) {
-								parentItem.click();
-								parentItem.focus();
-								setTimeout(() => focusDown(), 0);
-							}
-						}
-						return;
+			// Handle subgroup link navigation
+			if (isInSubgroupLink()) {
+				if (handleSubgroupLinkKey(e)) {
+					if (e.key !== "g") {
+						lastKeyRef.current = e.key;
+						lastKeyTimeRef.current = now;
 					}
-					case "j":
-					case "a":
-					case "ArrowLeft": {
-						e.preventDefault();
-						const links = getSubgroupLinks();
-						const currentIdx = links.indexOf(active);
-						if (currentIdx > 0) {
-							links[currentIdx - 1].focus();
-						} else {
-							const parentItem = getParentTrigger();
-							if (parentItem) {
-								parentItem.focus();
-							}
-						}
-						return;
-					}
-					case "k":
-					case "s":
-					case "ArrowDown": {
-						e.preventDefault();
-						const parentItem = getParentTrigger();
-						if (parentItem) {
-							parentItem.click();
-							parentItem.focus();
-							setTimeout(() => focusDown(), 0);
-						}
-						return;
-					}
-					case "i":
-					case "w":
-					case "ArrowUp": {
-						e.preventDefault();
-						const parentItem = getParentTrigger();
-						if (parentItem) {
-							parentItem.click();
-							parentItem.focus();
-							setTimeout(() => focusUp(), 0);
-						}
-						return;
-					}
-					case "q":
-					case "Escape": {
-						e.preventDefault();
-						const parentItem = getParentTrigger();
-						if (parentItem) {
-							parentItem.click();
-							parentItem.focus();
-						}
-						return;
-					}
-					case "Enter":
-					case " ":
-						return;
+					return;
 				}
 			}
 
-			switch (e.key) {
-				case "k":
-				case "s":
-				case "ArrowDown":
-					e.preventDefault();
-					focusDown();
-					break;
-				case "i":
-				case "w":
-				case "ArrowUp":
-					e.preventDefault();
-					focusUp();
-					break;
-				case "l":
-				case "d":
-				case "ArrowRight":
-					if (isInContainer && active) {
-						const isExpanded = active.getAttribute("aria-expanded") === "true";
-						const isTrigger = active.classList.contains(
-							"section-list__trigger",
-						);
-
-						if (isTrigger) {
-							if (isExpanded) {
-								e.preventDefault();
-								const links = getSubgroupLinks();
-								if (links.length > 0) {
-									links[0].focus();
-								} else {
-									active.click();
-									focusDown();
-								}
-							} else {
-								e.preventDefault();
-								active.click();
-							}
-						} else {
-							e.preventDefault();
-							focusRight();
-						}
-					} else {
-						// Not in container or no active element - start navigation
-						e.preventDefault();
-						focusRight();
-					}
-					break;
-				case "j":
-				case "a":
-				case "ArrowLeft":
-					if (isInContainer && active) {
-						const isExpanded = active.getAttribute("aria-expanded") === "true";
-						const isTrigger = active.classList.contains(
-							"section-list__trigger",
-						);
-
-						if (isTrigger && isExpanded) {
-							e.preventDefault();
-							active.click();
-						} else {
-							e.preventDefault();
-							focusLeft();
-						}
-					} else {
-						// Not in container or no active element - start navigation
-						e.preventDefault();
-						focusLeft();
-					}
-					break;
-				case "q":
-				case "Escape":
-					if (isInContainer && active) {
-						if (active.getAttribute("aria-expanded") === "true") {
-							e.preventDefault();
-							active.click();
-						}
-					}
-					break;
-				case "g":
-					if (
-						lastKeyRef.current === "g" &&
-						now - lastKeyTimeRef.current < 500
-					) {
-						e.preventDefault();
-						focusFirst();
-						window.scrollTo({ top: 0, behavior: "smooth" });
-						lastKeyRef.current = "";
-						return;
-					}
-					lastKeyRef.current = "g";
-					lastKeyTimeRef.current = now;
-					return;
-				case "G":
-				case "End":
-					e.preventDefault();
-					focusLast();
-					window.scrollTo({
-						top: document.body.scrollHeight,
-						behavior: "smooth",
-					});
-					break;
-				case "Home":
-					e.preventDefault();
-					focusFirst();
-					window.scrollTo({ top: 0, behavior: "smooth" });
-					break;
-				default:
-					if (e.key >= "1" && e.key <= "4") {
-						e.preventDefault();
-						const sectionIndex = Number.parseInt(e.key, 10) - 1;
-						const sections = containerRef.current?.querySelectorAll("section");
-						if (sections?.[sectionIndex]) {
-							const section = sections[sectionIndex];
-							section.scrollIntoView({ behavior: "smooth", block: "start" });
-							const firstFocusable = section.querySelector<HTMLElement>(
-								'[tabindex="0"], a[href]',
-							);
-							firstFocusable?.focus();
-						}
-					}
+			// Handle double-key sequence (gg)
+			if (handleDoubleKeySequence(e.key, now)) {
+				return;
 			}
 
+			// Handle main navigation
+			handleMainNavigationKey(e, isInContainer, active);
+
+			// Update key tracking
 			if (e.key !== "g") {
 				lastKeyRef.current = e.key;
 				lastKeyTimeRef.current = now;
 			}
 		};
 
-		window.addEventListener("keydown", handleKeyDown);
-		return () => window.removeEventListener("keydown", handleKeyDown);
+		globalThis.addEventListener("keydown", handleKeyDown);
+		return () => globalThis.removeEventListener("keydown", handleKeyDown);
 	}, [
-		containerRef,
 		disabled,
-		focusDown,
-		focusUp,
-		focusLeft,
-		focusRight,
-		focusFirst,
-		focusLast,
-		getSubgroupLinks,
+		containerRef,
 		isInSubgroupLink,
-		getParentTrigger,
-		zoomIn,
-		zoomOut,
+		handleSubgroupLinkKey,
+		handleDoubleKeySequence,
+		handleMainNavigationKey,
 	]);
 }

--- a/app/themes/mono/hooks/useVimNavigation.ts
+++ b/app/themes/mono/hooks/useVimNavigation.ts
@@ -251,10 +251,7 @@ export function useVimNavigation({
 	const handleDoubleKeySequence = useCallback(
 		(key: string, now: number): boolean => {
 			if (key === "g") {
-				if (
-					lastKeyRef.current === "g" &&
-					now - lastKeyTimeRef.current < 500
-				) {
+				if (lastKeyRef.current === "g" && now - lastKeyTimeRef.current < 500) {
 					focusFirst();
 					window.scrollTo({ top: 0, behavior: "smooth" });
 					lastKeyRef.current = "";

--- a/app/themes/mono/index.tsx
+++ b/app/themes/mono/index.tsx
@@ -167,6 +167,17 @@ const MonoTheme: React.FC = () => {
 
 	return (
 		<div className="mono-portfolio-wrapper theme-mono">
+			<canvas
+				ref={canvasRef}
+				aria-hidden="true"
+				style={{
+					position: "absolute",
+					top: 0,
+					left: 0,
+					pointerEvents: "none",
+					zIndex: 0,
+				}}
+			/>
 			<div className="mono-portfolio" ref={containerRef}>
 				<a href="#main-content" className="skip-link">
 					Skip to content

--- a/app/themes/mono/index.tsx
+++ b/app/themes/mono/index.tsx
@@ -50,8 +50,8 @@ const MonoTheme: React.FC = () => {
 			}
 		};
 
-		window.addEventListener("keydown", handleKeyDown);
-		return () => window.removeEventListener("keydown", handleKeyDown);
+		globalThis.addEventListener("keydown", handleKeyDown);
+		return () => globalThis.removeEventListener("keydown", handleKeyDown);
 	}, [isGuideOpen, handleOpenGuide]);
 
 	return (

--- a/app/themes/mono/index.tsx
+++ b/app/themes/mono/index.tsx
@@ -8,7 +8,6 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { monoThemeConfig } from "../../types/theme";
 import AsciiFooter from "./components/AsciiFooter";
 import EducationList from "./components/EducationList";
 import ExperienceList from "./components/ExperienceList";
@@ -20,122 +19,12 @@ import Shader from "@/components/ui/shader";
 
 const GuideModal = lazy(() => import("../../components/shared/GuideModal"));
 
-const {
-	gridSize: GRID_SIZE,
-	decayMs: DECAY_MS,
-	maxTiles: MAX_TILES,
-	palette: COLOR_PALETTE,
-} = monoThemeConfig.grid;
-
-interface GridHighlight {
-	x: number;
-	y: number;
-	color: string;
-	createdAt: number;
-}
-
 const MonoTheme: React.FC = () => {
 	const containerRef = useRef<HTMLDivElement>(null);
-	const canvasRef = useRef<HTMLCanvasElement>(null);
-	const highlightsRef = useRef<Map<string, GridHighlight>>(new Map());
-	const animationFrameRef = useRef<number | null>(null);
 	const [isGuideOpen, setIsGuideOpen] = useState(false);
 	const [guideEverOpened, setGuideEverOpened] = useState(false);
 
 	useVimNavigation({ containerRef, disabled: isGuideOpen });
-
-	useEffect(() => {
-		const canvas = canvasRef.current;
-		if (!canvas) return;
-
-		const ctx = canvas.getContext("2d");
-		if (!ctx) return;
-
-		const resizeCanvas = () => {
-			const docHeight = Math.max(
-				document.body.scrollHeight,
-				document.documentElement.scrollHeight,
-			);
-			canvas.width = window.innerWidth;
-			canvas.height = docHeight;
-		};
-
-		resizeCanvas();
-		window.addEventListener("resize", resizeCanvas);
-
-		const makeKey = (x: number, y: number) => `${x},${y}`;
-		const getRandomColor = () =>
-			COLOR_PALETTE[Math.floor(Math.random() * COLOR_PALETTE.length)];
-
-		const addHighlight = (pageX: number, pageY: number) => {
-			const x = Math.floor(pageX / GRID_SIZE) * GRID_SIZE;
-			const y = Math.floor(pageY / GRID_SIZE) * GRID_SIZE;
-			const key = makeKey(x, y);
-			const now = Date.now();
-			const highlights = highlightsRef.current;
-
-			const existing = highlights.get(key);
-			if (existing) {
-				existing.createdAt = now;
-			} else {
-				highlights.set(key, { x, y, color: getRandomColor(), createdAt: now });
-				if (highlights.size > MAX_TILES) {
-					const sorted = Array.from(highlights.entries()).sort(
-						(a, b) => a[1].createdAt - b[1].createdAt,
-					);
-					for (let i = 0; i < sorted.length - MAX_TILES; i++) {
-						highlights.delete(sorted[i][0]);
-					}
-				}
-			}
-		};
-
-		const render = () => {
-			const now = Date.now();
-			const highlights = highlightsRef.current;
-
-			ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-			let hasActive = false;
-			for (const [key, h] of highlights) {
-				const age = now - h.createdAt;
-				if (age > DECAY_MS) {
-					highlights.delete(key);
-				} else {
-					hasActive = true;
-					const opacity = Math.max(0, 1 - age / DECAY_MS);
-					const baseColor = h.color.replace(/[\d.]+\)$/, `${opacity * 0.35})`);
-					ctx.fillStyle = baseColor;
-					ctx.fillRect(h.x, h.y, GRID_SIZE, GRID_SIZE);
-				}
-			}
-
-			if (hasActive) {
-				animationFrameRef.current = requestAnimationFrame(render);
-			} else {
-				animationFrameRef.current = null;
-			}
-		};
-
-		const onMouseMove = (e: MouseEvent) => {
-			addHighlight(e.pageX, e.pageY);
-
-			if (animationFrameRef.current === null) {
-				animationFrameRef.current = requestAnimationFrame(render);
-			}
-		};
-
-		window.addEventListener("mousemove", onMouseMove, { passive: true });
-
-		return () => {
-			window.removeEventListener("mousemove", onMouseMove);
-			window.removeEventListener("resize", resizeCanvas);
-			if (animationFrameRef.current !== null) {
-				cancelAnimationFrame(animationFrameRef.current);
-				animationFrameRef.current = null;
-			}
-		};
-	}, []);
 
 	const handleOpenGuide = useCallback(() => {
 		setIsGuideOpen(true);
@@ -167,17 +56,6 @@ const MonoTheme: React.FC = () => {
 
 	return (
 		<div className="mono-portfolio-wrapper theme-mono">
-			<canvas
-				ref={canvasRef}
-				aria-hidden="true"
-				style={{
-					position: "absolute",
-					top: 0,
-					left: 0,
-					pointerEvents: "none",
-					zIndex: 0,
-				}}
-			/>
 			<div className="mono-portfolio" ref={containerRef}>
 				<a href="#main-content" className="skip-link">
 					Skip to content

--- a/app/themes/mono/styles/v2.scss
+++ b/app/themes/mono/styles/v2.scss
@@ -1,24 +1,9 @@
 // v2 Mono Portfolio Styles
 
-$grid-size: 60px;
-$grid-color: rgba(255, 255, 255, 0.035);
-
 .mono-portfolio-wrapper {
   min-height: 100vh;
   background: #0d0d0f;
   position: relative;
-
-  &::before {
-    content: '';
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient($grid-color 1px, transparent 1px),
-      linear-gradient(90deg, $grid-color 1px, transparent 1px);
-    background-size: $grid-size $grid-size;
-    pointer-events: none;
-    z-index: 1;
-  }
 }
 
 .mono-portfolio {
@@ -500,9 +485,10 @@ $grid-color: rgba(255, 255, 255, 0.035);
   }
 
   .ascii-footer {
-    text-align: left;
+    text-align: center;
     margin-top: 0;
     padding-top: 0;
+    overflow-x: clip;
 
     &__art {
       white-space: pre;
@@ -511,15 +497,9 @@ $grid-color: rgba(255, 255, 255, 0.035);
       color: var(--text);
       margin-bottom: 1rem;
 
-      // Prevent horizontal overflow on narrow screens
       @media (max-width: 600px) {
-        font-size: 0.625rem;
-        overflow-x: auto;
-        max-width: 100%;
-      }
-
-      @media (max-width: 400px) {
-        display: none;
+        font-size: 0.5rem;
+        line-height: 1.2;
       }
     }
   }

--- a/app/themes/mono/styles/v2.scss
+++ b/app/themes/mono/styles/v2.scss
@@ -7,12 +7,12 @@ $grid-color: rgba(255, 255, 255, 0.035);
   min-height: 100vh;
   background: #0d0d0f;
   position: relative;
-  
+
   &::before {
     content: '';
     position: fixed;
     inset: 0;
-    background-image: 
+    background-image:
       linear-gradient($grid-color 1px, transparent 1px),
       linear-gradient(90deg, $grid-color 1px, transparent 1px);
     background-size: $grid-size $grid-size;
@@ -28,7 +28,8 @@ $grid-color: rgba(255, 255, 255, 0.035);
   --bg-hover: rgba(255, 255, 255, 0.06);
   --text: #e8e8ec;
   --text-soft: #b6b6b6;
-  --text-muted: #71717a;
+  // Increased from #71717a → #8a8a94 for WCAG AA contrast (≥ 4.5:1 on #050506 bg)
+  --text-muted: #8a8a94;
   --border: rgba(255, 255, 255, 0.1);
   --accent: #60a5fa;
   --accent-hover: #3b82f6;
@@ -38,7 +39,8 @@ $grid-color: rgba(255, 255, 255, 0.035);
 
 
   font-family: 'CommitMono', monospace;
-  max-width: 100%;
+  // Cap width on ultra-wide displays while staying fluid within that
+  max-width: 1600px;
   margin: 0 auto;
   padding: 3rem 2.5rem;
   color: var(--text);
@@ -50,10 +52,14 @@ $grid-color: rgba(255, 255, 255, 0.035);
   z-index: 2;
   transform-origin: top center;
 
+  @media (max-width: 1200px) {
+    padding: 2.5rem 2rem;
+  }
+
   @media (max-width: 900px) {
     padding: 2rem 1.5rem;
   }
-  
+
   @media (max-width: 480px) {
     padding: 1.5rem 1rem;
   }
@@ -87,12 +93,13 @@ $grid-color: rgba(255, 255, 255, 0.035);
     margin: 0;
   }
 
-  p , li{
+  // Removed !important — more specific rules in detail-panel can now override correctly
+  p, li {
     font-size: 0.9375rem;
     margin: 0 0 1.25rem;
     letter-spacing: -0.02em;
     line-height: 1.8;
-    color: var(--text-soft) !important;
+    color: var(--text-soft);
   }
 
   hr {
@@ -106,6 +113,11 @@ $grid-color: rgba(255, 255, 255, 0.035);
     grid-template-columns: 2fr 3fr;
     gap: 12rem;
     align-items: start;
+
+    // Tighten the gap at mid-range widths to avoid cramped columns
+    @media (max-width: 1200px) {
+      gap: 5rem;
+    }
 
     &__left {
       position: sticky;
@@ -186,7 +198,7 @@ $grid-color: rgba(255, 255, 255, 0.035);
       width: 0.5rem;
       height: 0.5rem;
       border-radius: 50%;
-      
+
       &--red { background: #ff5f57; }
       &--yellow { background: #febc2e; }
       &--green { background: #28c840; }
@@ -275,11 +287,13 @@ $grid-color: rgba(255, 255, 255, 0.035);
     &::before { content: '['; color: var(--text-muted); }
     &::after { content: ']'; color: var(--text-muted); }
 
-    &:hover,
-    &:focus {
+    &:hover {
       color: var(--accent-hover);
       text-decoration: none;
-      text-decoration-color: var(--accent);
+    }
+
+    &:focus {
+      color: var(--accent-hover);
       outline: none;
     }
 
@@ -294,7 +308,7 @@ $grid-color: rgba(255, 255, 255, 0.035);
     margin: 0;
     padding: 0;
 
-    
+
     &__year {
       font-size: 0.875rem;
       color: var(--text-muted);
@@ -340,6 +354,8 @@ $grid-color: rgba(255, 255, 255, 0.035);
 
       &:focus-visible {
         background-color: var(--bg-surface);
+        outline: 2px solid var(--accent);
+        outline-offset: -2px;
       }
 
       &:focus,
@@ -398,11 +414,15 @@ $grid-color: rgba(255, 255, 255, 0.035);
       cursor: pointer;
       transition: color 150ms ease;
 
-      &:hover,
-      &:focus {
+      &:hover {
         color: var(--accent);
         text-decoration: underline;
         text-decoration-color: var(--accent);
+      }
+
+      &:focus {
+        color: var(--accent);
+        outline: none;
       }
 
       &:focus-visible {
@@ -456,6 +476,7 @@ $grid-color: rgba(255, 255, 255, 0.035);
         font-size: 0.875rem;
         color: var(--text);
         line-height: 1.6;
+        margin: 0;
         padding-left: 1rem;
         position: relative;
 
@@ -489,6 +510,17 @@ $grid-color: rgba(255, 255, 255, 0.035);
       line-height: 1.4;
       color: var(--text);
       margin-bottom: 1rem;
+
+      // Prevent horizontal overflow on narrow screens
+      @media (max-width: 600px) {
+        font-size: 0.625rem;
+        overflow-x: auto;
+        max-width: 100%;
+      }
+
+      @media (max-width: 400px) {
+        display: none;
+      }
     }
   }
 }

--- a/app/types/theme.ts
+++ b/app/types/theme.ts
@@ -1,17 +1,9 @@
 type ThemeId = "mono";
 
-interface GridConfig {
-	gridSize: number;
-	decayMs: number;
-	maxTiles: number;
-	palette: string[];
-}
-
 interface ThemeConfig {
 	id: ThemeId;
 	name: string;
 	description: string;
-	grid: GridConfig;
 }
 
 // Mono theme configuration
@@ -19,24 +11,4 @@ export const monoThemeConfig: ThemeConfig = {
 	id: "mono",
 	name: "Mono",
 	description: "Mono, keyboard-first",
-	grid: {
-		gridSize: 60,
-		decayMs: 1200,
-		maxTiles: 50,
-		palette: [
-			"rgba(167, 139, 250, 0.35)", // purple (ai)
-			"rgba(94, 234, 212, 0.35)", // teal (cv)
-			"rgba(147, 197, 253, 0.35)", // blue (ts)
-			"rgba(110, 231, 183, 0.35)", // green (py)
-			"rgba(134, 239, 172, 0.35)", // lime (csharp)
-			"rgba(252, 211, 77, 0.35)", // yellow (hardware)
-			"rgba(125, 211, 252, 0.35)", // cyan (azure)
-			"rgba(163, 230, 53, 0.35)", // lime-green (iot)
-			"rgba(251, 191, 36, 0.35)", // amber (ml)
-			"rgba(252, 165, 165, 0.35)", // red (threejs)
-			"rgba(249, 168, 212, 0.35)", // pink (rtmp)
-			"rgba(216, 180, 254, 0.35)", // violet (neuro)
-			"rgba(103, 232, 249, 0.35)", // sky (rnd)
-		],
-	},
 };

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - sharp

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+
+Sitemap: https://carsonsgit.github.io/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://carsonsgit.github.io/</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
WCAG:
- Add canvas to JSX with aria-hidden (was never rendered; grid highlight effect now works)
- GuideModal: add role=dialog, aria-modal, aria-labelledby, focus trap, focus close button on open
- Add .sr-only utility class to globals.scss
- AsciiFooter: add sr-only "Thanks for stopping by!" for screen readers
- BracketLink: inject sr-only "(opens in new tab)" when target=_blank
- ExperienceList/EducationList: sr-only text on company links
- All sections (Intro/Projects/Experience/Education): add aria-labelledby + ids on headings
- Increase --text-muted from #71717a → #8a8a94 (WCAG AA 4.5:1 contrast on dark bg)
- Remove !important from p/li color rule so detail-panel colors apply correctly
- section-list__trigger: add :focus-visible outline
- guide-trigger: split hover/focus, add :focus-visible outline
- guide-modal__close: add :focus-visible outline

SEO:
- Canonical URL via metadata.alternates
- Richer page title and description mentioning Carson's role and schools
- Add authors and keywords metadata fields
- JSON-LD Person schema (name, jobTitle, sameAs, alumniOf, knowsAbout)
- Move <Script> inside <body> (valid HTML structure)
- Add <link rel="preconnect"> for cloud.umami.is
- Create public/sitemap.xml
- Update robots.txt with Sitemap directive

Responsiveness:
- Portfolio max-width: 1600px (prevents extreme stretching on ultrawide)
- New 1200px breakpoint: gap reduced from 12rem → 5rem (prevents cramped mid-range columns)
- ASCII art: smaller font on ≤600px, hidden on ≤400px to prevent horizontal overflow

Optimization:
- Avatar image: explicit width=56 height=56 to prevent CLS
- Intro subtitle already had fetchpriority via Avatar component

https://claude.ai/code/session_01TnCck6GrSfEZeUWY7jDwfj