### PR TITLE
Remove unused formatCaseStudyDate function causing TypeScript build error

### DIFF
--- a/app/case-studies/page.tsx
+++ b/app/case-studies/page.tsx
@@ -17,15 +17,6 @@ export const metadata = createPageMetadata({
 	],
 });
 
-function formatCaseStudyDate(value: string) {
-	return new Intl.DateTimeFormat("en", {
-		month: "short",
-		day: "numeric",
-		year: "numeric",
-		timeZone: "UTC",
-	}).format(new Date(`${value}T00:00:00Z`));
-}
-
 export default function CaseStudiesIndexPage() {
 	return (
 		<main className="case-study-page">


### PR DESCRIPTION
The function was left over from a previous version of the page and was
never called, triggering a noUnusedLocals TypeScript error that broke
the Vercel deployment.

https://claude.ai/code/session_016SLFh7FUugQVKALhi6pHzz