### PR TITLE
fix: add bottom margin to intro links on mobile

### DIFF
--- a/app/styles.scss
+++ b/app/styles.scss
@@ -813,6 +813,10 @@
       &__note {
         max-width: none;
       }
+
+      &__links {
+        margin-bottom: 0.75rem;
+      }
     }
 
     .section-list {


### PR DESCRIPTION
Adds 0.75rem bottom margin to .intro__links on mobile (≤720px) so
there is visible breathing room between the nav buttons and the shader
panel below them.

https://claude.ai/code/session_01RTKsMAgdgNMs3MjhUE6SFq