### PR TITLE
🎨 Palette: Improve accessibility of Command Palette and Guide Modal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-02-14 - Removed aria-hidden from focusable elements
+**Learning:** Found an accessibility issue pattern where `aria-hidden="true"` was placed on elements (`<kbd>`) inside a focusable `<button>`. This can confuse screen readers since the element is reachable via keyboard but hidden from the accessibility tree. Biome's `lint/a11y/noAriaHiddenOnFocusable` rule correctly identifies this.
+**Action:** When adding decorative elements or keyboard shortcuts inside buttons, avoid `aria-hidden="true"`. Let the screen reader announce the contents of the button naturally, or use `aria-label` on the button itself if the visual content isn't sufficient.
+
+## 2025-02-14 - Added ARIA label to Command Palette Input
+**Learning:** The Command Palette `<input>` relied solely on a visual `placeholder` ("Search commands…"). Placeholders are not a replacement for proper labels in assistive technologies.
+**Action:** Always ensure `<input>` fields, especially those without visible `<label>` elements like search or command palette inputs, have an explicit `aria-label` to provide context to screen reader users.

--- a/app/case-studies/[slug]/page.tsx
+++ b/app/case-studies/[slug]/page.tsx
@@ -121,7 +121,7 @@ export default async function CaseStudyPage({ params }: PageProps) {
 			className="case-study-page"
 			data-accent={caseStudy.presentation?.accent ?? "mist"}
 		>
-				<article className="case-study-shell case-study-shell--article">
+			<article className="case-study-shell case-study-shell--article">
 				<script
 					type="application/ld+json"
 					// biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD with trusted local data

--- a/app/components/shared/CommandPalette.tsx
+++ b/app/components/shared/CommandPalette.tsx
@@ -23,18 +23,45 @@ const CommandPalette: React.FC = () => {
 	const items = useMemo<PaletteItem[]>(
 		() => [
 			{ id: "home", label: "Home", hint: "/", href: "/" },
-			{ id: "case-studies", label: "Case Studies", hint: "/case-studies", href: "/case-studies" },
-			{ id: "argus", label: "Argus", hint: "/case-studies/argus", href: "/case-studies/argus" },
-			{ id: "cropcare", label: "CropCare", hint: "/case-studies/cropcare", href: "/case-studies/cropcare" },
-			{ id: "linky", label: "Linky", hint: "/case-studies/linky", href: "/case-studies/linky" },
-			{ id: "theme", label: "Toggle theme", hint: "light / dark", action: toggle },
+			{
+				id: "case-studies",
+				label: "Case Studies",
+				hint: "/case-studies",
+				href: "/case-studies",
+			},
+			{
+				id: "argus",
+				label: "Argus",
+				hint: "/case-studies/argus",
+				href: "/case-studies/argus",
+			},
+			{
+				id: "cropcare",
+				label: "CropCare",
+				hint: "/case-studies/cropcare",
+				href: "/case-studies/cropcare",
+			},
+			{
+				id: "linky",
+				label: "Linky",
+				hint: "/case-studies/linky",
+				href: "/case-studies/linky",
+			},
+			{
+				id: "theme",
+				label: "Toggle theme",
+				hint: "light / dark",
+				action: toggle,
+			},
 		],
 		[toggle],
 	);
 
 	const filtered = useMemo(() => {
 		const q = query.trim().toLowerCase();
-		return q ? items.filter((item) => item.label.toLowerCase().includes(q)) : items;
+		return q
+			? items.filter((item) => item.label.toLowerCase().includes(q))
+			: items;
 	}, [items, query]);
 
 	const openPalette = () => {
@@ -122,10 +149,13 @@ const CommandPalette: React.FC = () => {
 			>
 				<div className="cmd-palette__input-row">
 					<input
-						ref={(el) => { if (isOpen) el?.focus(); }}
+						ref={(el) => {
+							if (isOpen) el?.focus();
+						}}
 						type="text"
 						className="cmd-palette__input"
 						placeholder="Search commands…"
+						aria-label="Search commands"
 						value={query}
 						onChange={handleQueryChange}
 						onKeyDown={handleKeyDown}

--- a/app/components/shared/GuideModal.tsx
+++ b/app/components/shared/GuideModal.tsx
@@ -101,8 +101,7 @@ const GuideModal: React.FC<GuideModalProps> = ({ isOpen, onClose }) => {
 								onClick={onClose}
 								aria-label="Close guide"
 							>
-								<kbd aria-hidden="true">?</kbd> /{" "}
-								<kbd aria-hidden="true">Esc</kbd>
+								<kbd>?</kbd> / <kbd>Esc</kbd>
 							</button>
 						</div>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -158,7 +158,12 @@ export default function RootLayout({
 	readonly children: React.ReactNode;
 }) {
 	return (
-		<html lang="en-CA" data-theme="mono" data-mode="light" suppressHydrationWarning>
+		<html
+			lang="en-CA"
+			data-theme="mono"
+			data-mode="light"
+			suppressHydrationWarning
+		>
 			<head>
 				<script
 					// biome-ignore lint/security/noDangerouslySetInnerHtml: static bootstrap to prevent FOUC, no user input

--- a/app/themes/mono/components/EducationList.tsx
+++ b/app/themes/mono/components/EducationList.tsx
@@ -54,7 +54,12 @@ const EducationList = () => {
 										<div className="detail-panel__intro">
 											<p className="detail-panel__meta">
 												{dateRange}
-												<span className="detail-panel__meta-sep" aria-hidden="true">·</span>
+												<span
+													className="detail-panel__meta-sep"
+													aria-hidden="true"
+												>
+													·
+												</span>
 												Study & training
 											</p>
 										</div>
@@ -70,10 +75,7 @@ const EducationList = () => {
 										</ul>
 										<div className="detail-panel__badges">
 											{Object.values(item.experienceBadges).map((badge) => (
-												<span
-													key={badge.label}
-													className="detail-panel__badge"
-												>
+												<span key={badge.label} className="detail-panel__badge">
 													{badge.label}
 												</span>
 											))}

--- a/app/themes/mono/components/ExperienceList.tsx
+++ b/app/themes/mono/components/ExperienceList.tsx
@@ -54,7 +54,12 @@ const ExperienceList = () => {
 										<div className="detail-panel__intro">
 											<p className="detail-panel__meta">
 												{dateRange}
-												<span className="detail-panel__meta-sep" aria-hidden="true">·</span>
+												<span
+													className="detail-panel__meta-sep"
+													aria-hidden="true"
+												>
+													·
+												</span>
 												Experience
 											</p>
 										</div>
@@ -70,10 +75,7 @@ const ExperienceList = () => {
 										</ul>
 										<div className="detail-panel__badges">
 											{Object.values(item.experienceBadges).map((badge) => (
-												<span
-													key={badge.label}
-													className="detail-panel__badge"
-												>
+												<span key={badge.label} className="detail-panel__badge">
 													{badge.label}
 												</span>
 											))}

--- a/app/themes/mono/components/Intro.tsx
+++ b/app/themes/mono/components/Intro.tsx
@@ -57,10 +57,10 @@ const Intro = () => {
 				</div>
 			</div>
 			<p className="intro__about">
-				Canada-based software engineer building product-focused web
-				experiences, internal tools, and clear technical work. I ship
-				customer-facing software at Fundica and study Engineering Technology and
-				Applied Sciences at Memorial University.
+				Canada-based software engineer building product-focused web experiences,
+				internal tools, and clear technical work. I ship customer-facing
+				software at Fundica and study Engineering Technology and Applied
+				Sciences at Memorial University.
 			</p>
 			<p className="intro__note">
 				Based in Canada. Focused on practical software, thoughtful interfaces,

--- a/app/themes/mono/components/ProjectDetail.tsx
+++ b/app/themes/mono/components/ProjectDetail.tsx
@@ -22,11 +22,16 @@ const ProjectDetail = ({
 			<div className="detail-panel__intro">
 				<p className="detail-panel__meta">
 					{year}
-					<span className="detail-panel__meta-sep" aria-hidden="true">·</span>
+					<span className="detail-panel__meta-sep" aria-hidden="true">
+						·
+					</span>
 					{caseStudySlug ? "Case study" : "Project"}
 				</p>
 			</div>
-			<ul className="detail-panel__tech-list" aria-label={`${projectTitle} stack`}>
+			<ul
+				className="detail-panel__tech-list"
+				aria-label={`${projectTitle} stack`}
+			>
 				{stack.map((item) => (
 					<li key={item.name} className="detail-panel__tech-item">
 						<span className="detail-panel__tech-pill">{item.name}</span>

--- a/app/themes/mono/hooks/useVimNavigation.ts
+++ b/app/themes/mono/hooks/useVimNavigation.ts
@@ -425,7 +425,8 @@ export function useVimNavigation({
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
 			if (disabled) return;
-			if (document.documentElement.getAttribute("data-palette-open") === "true") return;
+			if (document.documentElement.getAttribute("data-palette-open") === "true")
+				return;
 
 			if (
 				e.target instanceof HTMLInputElement ||


### PR DESCRIPTION
💡 **What:** 
- Added an `aria-label` to the search input in the `CommandPalette`.
- Removed `aria-hidden="true"` from the `<kbd>` elements nested inside the focusable close button in `GuideModal`.

🎯 **Why:** 
- `placeholder` text is not a reliable substitute for an explicit label for screen readers.
- Screen readers can be confused or read content incorrectly when elements inside a focusable interactive element (like a `<button>`) are explicitly hidden from the accessibility tree using `aria-hidden="true"`.

♿ **Accessibility:** 
- Fixes Biome's `lint/a11y/noAriaHiddenOnFocusable` warning.
- Ensures the primary input in the Command Palette is correctly announced by screen readers.

*(Ran `pnpm biome format --write` and `pnpm biome check .` to ensure codebase meets formatting standards.)*

---
*PR created automatically by Jules for task [14955842722862288218](https://jules.google.com/task/14955842722862288218) started by @carsonSgit*