### PR TITLE
[codex] Add Scour CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check Scour installation
-        run: scour --version
+      - name: Scour doctor
+        uses: carsonSgit/scour@v0.3.1
+        with:
+          since: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || github.event.before }}
+          format: doctor
+          exit-zero: "true"
 
-      - name: Scour
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            SCOUR_REF="origin/${{ github.base_ref }}"
-          else
-            SCOUR_REF="${{ github.event.before }}"
-          fi
-
-          scour --since "$SCOUR_REF" --format doctor --exit-zero
-          scour --since "$SCOUR_REF" --format github --fail-on error
+      - name: Scour annotations
+        uses: carsonSgit/scour@v0.3.1
+        with:
+          since: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || github.event.before }}
+          format: github
+          fail-on: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check Scour installation
+        run: scour --version
+
+      - name: Scour
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            SCOUR_REF="origin/${{ github.base_ref }}"
+          else
+            SCOUR_REF="${{ github.event.before }}"
+          fi
+
+          scour --since "$SCOUR_REF" --format doctor --exit-zero
+          scour --since "$SCOUR_REF" --format github --fail-on error

--- a/package.json
+++ b/package.json
@@ -22,8 +22,6 @@
 		"build": "next build",
 		"start": "npx serve@latest ./out",
 		"predeploy": "pnpm build",
-		"ci": "pnpm scour",
-		"scour": "scour --since HEAD --format doctor --fail-on error",
 		"format": "pnpm biome format --write",
 		"lint:unused": "knip"
 	},

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
 		"build": "next build",
 		"start": "npx serve@latest ./out",
 		"predeploy": "pnpm build",
+		"ci": "pnpm scour",
+		"scour": "scour --since HEAD --format doctor --fail-on error",
 		"format": "pnpm biome format --write",
 		"lint:unused": "knip"
 	},


### PR DESCRIPTION
## Summary

Adds Scour to the project CI flow with readable local output and GitHub Actions annotations.

## Changes

- Adds `pnpm scour` and `pnpm run ci` scripts.
- Adds a GitHub Actions workflow that runs Scour on pull requests and pushes to `main`.
- Prints the `doctor` report in Actions logs, then runs the GitHub annotation format for inline PR feedback.

## Validation

- `pnpm run ci`
- `scour --since HEAD --format github --fail-on error`